### PR TITLE
Make added methods non-enumerable

### DIFF
--- a/can-define-backup.js
+++ b/can-define-backup.js
@@ -1,6 +1,5 @@
 "use strict";
 //allows you to backup and restore a map instance
-var assign = require('can-assign');
 var canReflect = require('can-reflect');
 var SimpleObservable = require('can-simple-observable');
 var diffDeep = require("can-diff/deep/deep");
@@ -18,6 +17,17 @@ var flatProps = function (a, cur) {
 	return obj;
 };
 
+var assignNonEnumerable = function(base, props) {
+	for(var prop in props) {
+		Object.defineProperty(base, prop, {
+			enumerable: false,
+			configurable: true,
+			writable: true,
+			value: props[prop]
+		});
+	}
+};
+
 var observables = new WeakMap();
 
 function getBackup(map) {
@@ -30,7 +40,7 @@ function getBackup(map) {
 }
 
 function defineBackup(Map) {
-	assign(Map.prototype, {
+	assignNonEnumerable(Map.prototype, {
 
 		backup: function () {
 			var store = getBackup(this);
@@ -77,7 +87,8 @@ function defineBackup(Map) {
 			return this;
 		}
 	});
-	return;
+
+	return Map;
 }
 
 module.exports = exports = defineBackup;

--- a/can-define-backup_test.js
+++ b/can-define-backup_test.js
@@ -2,7 +2,8 @@ var DefineMap = require('can-define/map/map');
 var Observation = require('can-observation');
 var canReflect = require('can-reflect');
 var defineBackup = require('can-define-backup');
-defineBackup(DefineMap);
+
+var MyMap = defineBackup(DefineMap.extend({}));
 
 require('steal-qunit');
 
@@ -10,7 +11,7 @@ var Recipe;
 
 QUnit.module('can/define/backup', {
 	setup: function () {
-		Recipe = DefineMap.extend('Recipe', {
+		Recipe = MyMap.extend('Recipe', {
 			name: 'string'
 		});
 	}
@@ -31,13 +32,13 @@ test('backing up', function () {
 });
 
 test('backup / restore with associations', function () {
-	var Instruction = DefineMap.extend('Instruction', {
+	var Instruction = MyMap.extend('Instruction', {
 		description: 'string'
 	});
-	var Cookbook = DefineMap.extend('Cookbook', {
+	var Cookbook = MyMap.extend('Cookbook', {
 		title: 'string'
 	});
-	var Recipe = DefineMap.extend('Recipe', {
+	var Recipe = MyMap.extend('Recipe', {
 		instructions: {
 			Type: Instruction.List
 		},
@@ -85,7 +86,7 @@ test('backup / restore with associations', function () {
 });
 
 test('backup restore nested observables', function () {
-	var observe = new DefineMap({
+	var observe = new MyMap({
 		nested: {
 			test: 'property'
 		}
@@ -103,7 +104,7 @@ test('backup restore nested observables', function () {
 });
 
 test('backup removes properties that were added (#607)', function () {
-	var map = new DefineMap({
+	var map = new MyMap({
 		foo: 'string'
 	});
 	map.backup();


### PR DESCRIPTION
This also makes it so that defineBackup returns the map passed in.